### PR TITLE
Update Javaparser Version to 3.26.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>de.jsilbereisen</groupId>
     <artifactId>perfumator-java</artifactId>
-    <version>0.3.0</version>
+    <version>0.3.1</version>
     <packaging>jar</packaging>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <!-- no submodules yet, placeholder for potential future modularization -->
 
         <!-- Dependency versions -->
-        <javaparser.version>3.25.4</javaparser.version>
+        <javaparser.version>3.26.2</javaparser.version>
         <args4j.version>2.33</args4j.version>
         <jackson.version>2.15.0</jackson.version>
         <lombok.version>1.18.26</lombok.version>


### PR DESCRIPTION
In order to support more recent Java features such as records and switch pattern matching, the Javaparser version is increased to `3.26.2`.  
Changelog: https://github.com/javaparser/javaparser/releases