### PR TITLE
Provide dependencies and better error handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>de.jsilbereisen</groupId>
     <artifactId>perfumator-java</artifactId>
-    <version>0.4.0</version>
+    <version>0.4.1</version>
     <packaging>jar</packaging>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -127,21 +127,18 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <version>${junit.version}</version>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
             <version>${junit.version}</version>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>${assertj.version}</version>
-            <scope>test</scope>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
@@ -149,7 +146,6 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito-core.version}</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/de/jsilbereisen/perfumator/engine/PerfumeDetectionEngine.java
+++ b/src/main/java/de/jsilbereisen/perfumator/engine/PerfumeDetectionEngine.java
@@ -110,7 +110,7 @@ public class PerfumeDetectionEngine implements DetectionEngine<Perfume> {
      * as it is used by the <i><b>Perfumator</b></i> by default.<br/>
      * List of settings that are changed, compared to the default {@link ParserConfiguration}:
      * <ul>
-     *     <li>Language level: 11 (default) -&gt; 17</li>
+     *     <li>Language level: 21</li>
      *     <li>Do NOT Capture empty line comments: {@code true} -&gt; {@code false}</li>
      * </ul>
      *

--- a/src/main/java/de/jsilbereisen/perfumator/engine/detector/perfume/JFrameDisposeDetector.java
+++ b/src/main/java/de/jsilbereisen/perfumator/engine/detector/perfume/JFrameDisposeDetector.java
@@ -3,6 +3,7 @@ package de.jsilbereisen.perfumator.engine.detector.perfume;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.resolution.model.typesystem.ReferenceTypeImpl;
+import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import de.jsilbereisen.perfumator.engine.detector.Detector;
 import de.jsilbereisen.perfumator.model.DetectedInstance;
@@ -52,7 +53,14 @@ public class JFrameDisposeDetector implements Detector<Perfume> {
             }
             var scope = expr.getScope();
             if (scope.isPresent()) {
-                var resolvedType = scope.get().calculateResolvedType();
+                ResolvedType resolvedType;
+                try {
+                    resolvedType = scope.get().calculateResolvedType();
+                } catch (Exception e) {
+                    System.out.println(expr.getNameAsString());
+                    System.out.println(e.getMessage());
+                    return false;
+                }
                 if (resolvedType instanceof ReferenceTypeImpl referenceType) {
                     return referenceType.getQualifiedName().equals(QUALIFIED_JFRAME_CLASS_NAME);
                 }

--- a/src/main/java/de/jsilbereisen/perfumator/engine/detector/perfume/SwingTimerDetector.java
+++ b/src/main/java/de/jsilbereisen/perfumator/engine/detector/perfume/SwingTimerDetector.java
@@ -2,7 +2,6 @@ package de.jsilbereisen.perfumator.engine.detector.perfume;
 
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
-import com.github.javaparser.resolution.UnsolvedSymbolException;
 import com.github.javaparser.resolution.model.typesystem.ReferenceTypeImpl;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
@@ -26,6 +25,7 @@ public class SwingTimerDetector implements Detector<Perfume> {
     private JavaParserFacade analysisContext;
     
     private static final String QUALIFIED_TIMER_NAME = "javax.swing.Timer";
+    private static final String TIMER_IDENTIFIER = "Timer";
     
     @Override
     public @NotNull List<DetectedInstance<Perfume>> detect(@NotNull CompilationUnit astRoot) {
@@ -48,12 +48,17 @@ public class SwingTimerDetector implements Detector<Perfume> {
     
     private List<ObjectCreationExpr> getNewTimerExpressions(@NotNull CompilationUnit astRoot) {
         return astRoot.findAll(ObjectCreationExpr.class, expr -> {
+            if (!expr.getType().getNameAsString().equals(TIMER_IDENTIFIER)) {
+                return false;
+            }
             ResolvedType resolvedType;
             // when classes from the same package are instantiated, the javaparser cannot resolve the type, therefore
             // we simply skip such occurrences of object creation expressions
             try {
                 resolvedType = expr.calculateResolvedType();
-            } catch (UnsolvedSymbolException e) {
+            } catch (Exception e) {
+                System.out.println(expr);
+                System.out.println(e.getMessage());
                 return false;
             }
             return resolvedType instanceof ReferenceTypeImpl referenceType 

--- a/src/main/java/de/jsilbereisen/perfumator/engine/detector/perfume/ThreadSafeSwingDetector.java
+++ b/src/main/java/de/jsilbereisen/perfumator/engine/detector/perfume/ThreadSafeSwingDetector.java
@@ -59,7 +59,14 @@ public class ThreadSafeSwingDetector implements Detector<Perfume> {
             }
             if (expr.getScope().isPresent()) {
                 // for non-static imports
-                ResolvedType resolvedType = expr.getScope().get().calculateResolvedType();
+                ResolvedType resolvedType;
+                try {
+                    resolvedType = expr.getScope().get().calculateResolvedType();
+                } catch (Exception e) {
+                    System.out.println(expr.getNameAsString());
+                    System.out.println(e.getMessage());
+                    return false;
+                }
                 return resolvedType instanceof ReferenceTypeImpl referenceType
                         && referenceType.getQualifiedName().equals(IMPORT);
             } else {


### PR DESCRIPTION
Some new Perfumes require `jar` files in order to find perfumes. This was not an issue in the tests, since the dependencies were available during testing. However, during runtime, they were not.

Additionally adds error handling to all new type-resolving operations, since these fail easily, but we still want to get the report for the other perfumes.